### PR TITLE
fix: replace import "dotenv/config" with explicit dotenv.config({ quiet: true })

### DIFF
--- a/samples/experiment/src/runner.ts
+++ b/samples/experiment/src/runner.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import dotenv from "dotenv";
+dotenv.config({ quiet: true });
 import { GraphAI, assert, GraphData } from "graphai";
 import * as vanillaAgents from "@graphai/vanilla";
 import { openAIAgent } from "@graphai/openai_agent";


### PR DESCRIPTION
## Summary
- Replace side-effect `import "dotenv/config"` with explicit `import dotenv from "dotenv"; dotenv.config({ quiet: true });`
- The old `import "dotenv/config"` pattern does not support the `quiet` option, which suppresses warnings about missing `.env` files

## Test plan
- [ ] Verify dotenv configuration still loads environment variables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)